### PR TITLE
fix: filter coins by pair_with when allow_list is empty

### DIFF
--- a/internal/market/coin.go
+++ b/internal/market/coin.go
@@ -45,6 +45,14 @@ func (c Coin) String() string {
 // IsAvailableForTrading checks if the coin should be picked up by the bot for trading.
 // It checks if the coin is in the custom list and if it's not a fiat currency, both of which are options defined in the given config.
 func (c Coin) IsAvailableForTrading(allowList, denyList []string, pairWith string) bool {
+	if len(denyList) > 0 {
+		if utils.Any(denyList, func(fiat string) bool {
+			return c.Symbol == fiat
+		}) {
+			return false
+		}
+	}
+
 	if len(allowList) > 0 {
 		if !utils.Any(allowList, func(allowedCoin string) bool {
 			allowedSymbol := fmt.Sprintf("%s%s", allowedCoin, pairWith)
@@ -52,14 +60,8 @@ func (c Coin) IsAvailableForTrading(allowList, denyList []string, pairWith strin
 		}) {
 			return false
 		}
-	}
-
-	if len(denyList) > 0 {
-		if utils.Any(denyList, func(fiat string) bool {
-			return c.Symbol == fiat
-		}) {
-			return false
-		}
+	} else {
+		return c.Symbol[len(c.Symbol)-len(pairWith):] == pairWith
 	}
 
 	return true

--- a/internal/market/coin_test.go
+++ b/internal/market/coin_test.go
@@ -22,6 +22,8 @@ func TestCoin_IsAvailableForTrading(t *testing.T) {
 	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
 	coin.Symbol = "EURUSDT"
 	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
+	coin.Symbol = "BTCUSDC"
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
 
 	// test no allowlist
 	coin.Symbol = "BTCUSDT"
@@ -29,6 +31,8 @@ func TestCoin_IsAvailableForTrading(t *testing.T) {
 	coin.Symbol = "ETHUSDT"
 	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
 	coin.Symbol = "EURUSDT"
+	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
+	coin.Symbol = "BTCUSDC"
 	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
 
 	// test no denylist
@@ -38,6 +42,8 @@ func TestCoin_IsAvailableForTrading(t *testing.T) {
 	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
 	coin.Symbol = "EURUSDT"
 	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
+	coin.Symbol = "BTCUSDC"
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
 
 	// test no allowlist and no denylist
 	coin.Symbol = "BTCUSDT"
@@ -46,4 +52,6 @@ func TestCoin_IsAvailableForTrading(t *testing.T) {
 	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
 	coin.Symbol = "EURUSDT"
 	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
+	coin.Symbol = "BTCUSDC"
+	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
 }


### PR DESCRIPTION
This PR fixes a bug where all coins would be traded if the allow_list was empty, regardless of their quote currency. The expected behavior is to check and trade only the coins with the quote asset defined in the pair_with config setting.

It may be beneficial to ensure that the 'pair_with' setting in the configuration file is not left empty. However, this is not addressed in this PR.