### PR TITLE
feat: filter coins by minimum traded volume

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -88,6 +88,10 @@ trading_options:
   # Set to 0 to disable.
   cool_off_delay: 0
 
+  # Trading volume threshold in pair_with currency for a coin to be considered for trading.
+  # For Binance, this value refers to the 24h quote asset trading volume of the coin.
+  min_quote_volume_traded: 100000
+
   # Configuration for trailing stop loss.
   trailing_stop_options:
     # Whether to enable trailing stop loss.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -75,7 +75,7 @@ func (b *Bot) buy(ctx context.Context, wg *sync.WaitGroup) {
 		panic(fmt.Sprintf("failed to load initial latest coins: %s", err))
 	}
 
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(1 * time.Hour)
 	defer ticker.Stop()
 
 	for {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -52,8 +52,10 @@ func (b *Bot) Start(ctx context.Context) {
 	defer b.flushLogs()
 	b.botLog.Info("Bot started. Press CTRL + C to quit.")
 
-	if err := b.updateVolumeTraded(ctx); err != nil {
-		panic(fmt.Sprintf("failed to load initial volume traded: %s", err))
+	if b.config.TradingOptions.MinQuoteVolumeTraded != 0.0 {
+		if err := b.updateVolumeTraded(ctx); err != nil {
+			panic(fmt.Sprintf("failed to load initial volume traded: %s", err))
+		}
 	}
 
 	var wg sync.WaitGroup

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -22,6 +22,7 @@ type Bot struct {
 	market           market.Market
 	db               database.Database
 	volatilityWindow *VolatilityWindow
+	coinVolumes      market.CoinVolumeTradedMap
 	config           *config.Configuration
 	botLog           *zap.SugaredLogger
 	buyLog           *zap.SugaredLogger
@@ -388,7 +389,7 @@ func (b *Bot) updateVolumeTraded(ctx context.Context) error {
 		return err
 	}
 
-	market.CoinVolumes = volumeTraded
+	b.coinVolumes = volumeTraded
 
 	return nil
 }
@@ -400,6 +401,12 @@ func (b *Bot) updateLatestCoins(ctx context.Context) error {
 	coins, err := b.market.GetCoins(ctx)
 	if err != nil {
 		return err
+	}
+
+	for symbol, coin := range coins {
+		if quoteVolume, ok := b.coinVolumes[symbol]; ok {
+			coin.QuoteVolumeTraded = quoteVolume
+		}
 	}
 
 	b.volatilityWindow.AddRecord(coins)

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -22,7 +22,7 @@ type Bot struct {
 	market           market.Market
 	db               database.Database
 	volatilityWindow *VolatilityWindow
-	coinVolumes      market.CoinVolumeTradedMap
+	tradeVolumes     market.TradeVolumes
 	config           *config.Configuration
 	botLog           *zap.SugaredLogger
 	buyLog           *zap.SugaredLogger
@@ -389,7 +389,7 @@ func (b *Bot) updateVolumeTraded(ctx context.Context) error {
 		return err
 	}
 
-	b.coinVolumes = volumeTraded
+	b.tradeVolumes = volumeTraded
 
 	return nil
 }
@@ -404,7 +404,7 @@ func (b *Bot) updateLatestCoins(ctx context.Context) error {
 	}
 
 	for symbol, coin := range coins {
-		if quoteVolume, ok := b.coinVolumes[symbol]; ok {
+		if quoteVolume, ok := b.tradeVolumes[symbol]; ok {
 			coin.QuoteVolumeTraded = quoteVolume
 		}
 	}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -110,6 +110,12 @@ func (b *Bot) buy(ctx context.Context, wg *sync.WaitGroup) {
 			volatileCoins := b.volatilityWindow.IdentifyVolatileCoins(b.config.TradingOptions.ChangeInPrice)
 			b.buyLog.Infof("Found %d volatile coins.", len(volatileCoins))
 			for _, volatileCoin := range volatileCoins {
+
+				if !volatileCoin.Coin.IsAvailableForTrading(b.config.TradingOptions.AllowList, b.config.TradingOptions.DenyList, b.config.TradingOptions.PairWith, b.config.TradingOptions.MinQuoteVolumeTraded) {
+					b.buyLog.Debugf("Coin %s is not available for trading. Skipping.", volatileCoin.Symbol)
+					continue
+				}
+
 				b.buyLog.Infof("Coin %s has gained %.2f%% within the last %d minutes.", volatileCoin.Symbol, volatileCoin.Percentage, b.config.TradingOptions.TimeDifference)
 
 				// Skip if the coin has already been bought.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -52,6 +52,10 @@ func (b *Bot) Start(ctx context.Context) {
 	defer b.flushLogs()
 	b.botLog.Info("Bot started. Press CTRL + C to quit.")
 
+	if err := b.updateVolumeTraded(ctx); err != nil {
+		panic(fmt.Sprintf("failed to load initial volume traded: %s", err))
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -68,9 +72,6 @@ func (b *Bot) buy(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 	b.buyLog.Debug("Watching coins to buy.")
 
-	if err := b.updateVolumeTraded(ctx); err != nil {
-		panic(fmt.Sprintf("failed to load initial volume traded: %s", err))
-	}
 	if err := b.updateLatestCoins(ctx); err != nil {
 		panic(fmt.Sprintf("failed to load initial latest coins: %s", err))
 	}

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -40,7 +40,7 @@ func (m *mockMarket) Sell(ctx context.Context, coin string, quantity float64) (m
 	panic("implement me")
 }
 
-func (m *mockMarket) GetCoinsVolume(_ context.Context) (market.CoinVolumeTradedMap, error) {
+func (m *mockMarket) GetCoinsVolume(_ context.Context) (market.TradeVolumes, error) {
 	panic("implement me")
 }
 

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -133,41 +133,61 @@ func TestBot_buy(t *testing.T) {
 		EnableTestMode: true,
 		LoggingOptions: config.LoggingOptions{Enable: false},
 		TradingOptions: config.TradingOptions{
-			ChangeInPrice: 10, // 10%
-			PairWith:      "USDT",
-			Quantity:      10, // trade 10 USDT
+			ChangeInPrice:        10, // 10%
+			PairWith:             "USDT",
+			Quantity:             10, // trade 10 USDT
+			MinQuoteVolumeTraded: 100_000,
 		},
 	}
 
 	m := newMockMarket(cancel)
 	m.AddCoins(market.CoinMap{
 		"BTC": market.Coin{
-			Symbol: "BTC",
-			Price:  10_000,
+			Symbol:            "BTCUSDT",
+			Price:             10_000,
+			QuoteVolumeTraded: 50_000,
 		},
 		"ETH": market.Coin{
-			Symbol: "ETH",
-			Price:  10_000,
+			Symbol:            "ETHUSDT",
+			Price:             10_000,
+			QuoteVolumeTraded: 80_000,
 		},
 	})
 	m.AddCoins(market.CoinMap{
 		"BTC": market.Coin{
-			Symbol: "BTC",
-			Price:  10_500,
+			Symbol:            "BTCUSDT",
+			Price:             10_500,
+			QuoteVolumeTraded: 100_000,
 		},
 		"ETH": market.Coin{
-			Symbol: "ETH",
-			Price:  9_000,
+			Symbol:            "ETHUSDT",
+			Price:             9_000,
+			QuoteVolumeTraded: 20_000,
 		},
 	})
 	m.AddCoins(market.CoinMap{
 		"BTC": market.Coin{
-			Symbol: "BTC",
-			Price:  11_000,
+			Symbol:            "BTCUSDT",
+			Price:             11_000,
+			QuoteVolumeTraded: 120_000,
 		},
 		"ETH": market.Coin{
-			Symbol: "ETH",
-			Price:  10_000,
+			Symbol:            "ETHUSDT",
+			Price:             10_000,
+			QuoteVolumeTraded: 400_000,
+		},
+	})
+	// price change above threshold but not enough trading volume
+	m.AddCoins(market.CoinMap{
+		"BTC": market.Coin{
+			Symbol:            "BTCUSDT",
+			Price:             14_000,
+			QuoteVolumeTraded: 30_000,
+		},
+		"ETH": market.Coin{
+			Symbol:            "ETHUSDT",
+			Price:             13_000,
+			QuoteVolumeTraded: 40_000,
 		},
 	})
 
@@ -181,7 +201,7 @@ func TestBot_buy(t *testing.T) {
 
 	orders := db.GetOrders(models.BuyOrder, m.Name())
 	assert.Equal(t, 1, len(orders))
-	assert.Equal(t, "BTC", orders[0].Symbol)
+	assert.Equal(t, "BTCUSDT", orders[0].Symbol)
 	assert.Equal(t, 0.0009091, orders[0].Volume)
 }
 

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -13,10 +13,9 @@ import (
 )
 
 type mockMarket struct {
-	coinsIndex  int
-	coins       []market.CoinMap
-	coinsVolume market.CoinVolumeTradedMap
-	cancel      context.CancelFunc
+	coinsIndex int
+	coins      []market.CoinMap
+	cancel     context.CancelFunc
 }
 
 // ensure mockMarket implements the Market interface
@@ -42,7 +41,7 @@ func (m *mockMarket) Sell(ctx context.Context, coin string, quantity float64) (m
 }
 
 func (m *mockMarket) GetCoinsVolume(_ context.Context) (market.CoinVolumeTradedMap, error) {
-	return m.coinsVolume, nil
+	panic("implement me")
 }
 
 func (m *mockMarket) GetCoins(_ context.Context) (market.CoinMap, error) {

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -14,7 +14,7 @@ import (
 
 type mockMarket struct {
 	coinsIndex int
-	coins      []market.CoinMap
+	coins      []market.Coins
 	cancel     context.CancelFunc
 }
 
@@ -23,7 +23,7 @@ var _ market.Market = (*mockMarket)(nil)
 
 func newMockMarket(cancel context.CancelFunc) *mockMarket {
 	return &mockMarket{
-		coins:  make([]market.CoinMap, 0),
+		coins:  make([]market.Coins, 0),
 		cancel: cancel,
 	}
 }
@@ -44,7 +44,7 @@ func (m *mockMarket) GetCoinsVolume(_ context.Context) (market.TradeVolumes, err
 	panic("implement me")
 }
 
-func (m *mockMarket) GetCoins(_ context.Context) (market.CoinMap, error) {
+func (m *mockMarket) GetCoins(_ context.Context) (market.Coins, error) {
 	if m.coinsIndex >= len(m.coins) {
 		m.cancel()
 		return nil, fmt.Errorf("no coins found at index %d", m.coinsIndex)
@@ -57,7 +57,7 @@ func (m *mockMarket) GetCoins(_ context.Context) (market.CoinMap, error) {
 	return coins, nil
 }
 
-func (m *mockMarket) AddCoins(coins market.CoinMap) {
+func (m *mockMarket) AddCoins(coins market.Coins) {
 	m.coins = append(m.coins, coins)
 }
 
@@ -140,7 +140,7 @@ func TestBot_buy(t *testing.T) {
 	}
 
 	m := newMockMarket(cancel)
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol:            "BTCUSDT",
 			Price:             10_000,
@@ -152,7 +152,7 @@ func TestBot_buy(t *testing.T) {
 			QuoteVolumeTraded: 80_000,
 		},
 	})
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol:            "BTCUSDT",
 			Price:             10_500,
@@ -164,7 +164,7 @@ func TestBot_buy(t *testing.T) {
 			QuoteVolumeTraded: 20_000,
 		},
 	})
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol:            "BTCUSDT",
 			Price:             11_000,
@@ -177,7 +177,7 @@ func TestBot_buy(t *testing.T) {
 		},
 	})
 	// price change above threshold but not enough trading volume
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol:            "BTCUSDT",
 			Price:             14_000,
@@ -221,7 +221,7 @@ func TestBot_sell(t *testing.T) {
 	}
 
 	m := newMockMarket(cancel)
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"XTZUSDT": market.Coin{
 			Symbol: "XTZUSDT",
 			Price:  1.295,
@@ -273,19 +273,19 @@ func TestBot_sell_with_trailing_stop_loss(t *testing.T) {
 	}
 
 	m := newMockMarket(cancel)
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol: "BTC",
 			Price:  11_000,
 		},
 	})
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol: "BTC",
 			Price:  11_050,
 		},
 	})
-	m.AddCoins(market.CoinMap{
+	m.AddCoins(market.Coins{
 		"BTC": market.Coin{
 			Symbol: "BTC",
 			Price:  9000,

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type mockMarket struct {
-	coinsIndex int
-	coins      []market.CoinMap
-	cancel     context.CancelFunc
+	coinsIndex  int
+	coins       []market.CoinMap
+	coinsVolume market.CoinVolumeTradedMap
+	cancel      context.CancelFunc
 }
 
 // ensure mockMarket implements the Market interface
@@ -38,6 +39,10 @@ func (m *mockMarket) Buy(ctx context.Context, coin string, quantity float64) (ma
 
 func (m *mockMarket) Sell(ctx context.Context, coin string, quantity float64) (market.Order, error) {
 	panic("implement me")
+}
+
+func (m *mockMarket) GetCoinsVolume(_ context.Context) (market.CoinVolumeTradedMap, error) {
+	return m.coinsVolume, nil
 }
 
 func (m *mockMarket) GetCoins(_ context.Context) (market.CoinMap, error) {

--- a/internal/bot/volatility_window.go
+++ b/internal/bot/volatility_window.go
@@ -14,7 +14,7 @@ const UnlimitedVolatilityWindowLength = 0
 
 type VolatilityWindowRecord struct {
 	time  time.Time
-	coins market.CoinMap
+	coins market.Coins
 }
 
 type VolatilityWindow struct {
@@ -36,7 +36,7 @@ func (h *VolatilityWindow) Size() int {
 }
 
 // AddRecord adds a new record to the volatilityWindow.
-func (h *VolatilityWindow) AddRecord(coins market.CoinMap) {
+func (h *VolatilityWindow) AddRecord(coins market.Coins) {
 	if l := h.Size(); l == h.maxLength && l != UnlimitedVolatilityWindowLength {
 		// remove everything except the last record
 		// h.records = h.records[h.maxLength-1:]

--- a/internal/bot/volatility_window_test.go
+++ b/internal/bot/volatility_window_test.go
@@ -15,13 +15,13 @@ func TestVolatilityWindow_Size(t *testing.T) {
 
 func TestVolatilityWindow_Min(t *testing.T) {
 	window := NewVolatilityWindow(3)
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 10000.0},
 	})
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 8000.0},
 	})
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 20000.0},
 	})
 	m := window.Min("BTCUSDT")
@@ -30,13 +30,13 @@ func TestVolatilityWindow_Min(t *testing.T) {
 
 func TestVolatilityWindow_Max(t *testing.T) {
 	window := NewVolatilityWindow(3)
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 10000.0},
 	})
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 20000.0},
 	})
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 8000.0},
 	})
 	m := window.Max("BTCUSDT")
@@ -47,10 +47,10 @@ func TestVolatilityWindow_IdentifyVolatileCoins(t *testing.T) {
 	// Basic percentage increase check.
 	window := NewVolatilityWindow(UnlimitedVolatilityWindowLength)
 	percentage := 15.0
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 20_000.0},
 	})
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 23_000.0},
 	})
 	v := window.IdentifyVolatileCoins(percentage)
@@ -58,14 +58,14 @@ func TestVolatilityWindow_IdentifyVolatileCoins(t *testing.T) {
 
 	// This coin is already identified as volatile above.
 	// a sudden spike in price shouldn't affect the result within the current time window.
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"BTCUSDT": {Price: 25_000.0},
 	})
 	v = window.IdentifyVolatileCoins(percentage)
 	assert.Equal(t, percentage, v["BTCUSDT"].Percentage)
 
 	// A brand-new coin should not yet be volatile.
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"ETHUSDT": {Price: 3000},
 	})
 	v = window.IdentifyVolatileCoins(percentage)
@@ -73,7 +73,7 @@ func TestVolatilityWindow_IdentifyVolatileCoins(t *testing.T) {
 	assert.Equal(t, false, ok, vv.Percentage)
 
 	// Test price drop.
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"ETHUSDT": {Price: 2000},
 	})
 	v = window.IdentifyVolatileCoins(percentage)
@@ -81,7 +81,7 @@ func TestVolatilityWindow_IdentifyVolatileCoins(t *testing.T) {
 	assert.Equal(t, false, ok, vv.Percentage)
 
 	// Test price increase
-	window.AddRecord(market.CoinMap{
+	window.AddRecord(market.Coins{
 		"ETHUSDT": {Price: 10_000},
 	})
 	v = window.IdentifyVolatileCoins(percentage)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -119,6 +119,10 @@ type TradingOptions struct {
 	// Set to 0 to disable.
 	CoolOffDelay int `mapstructure:"cool_off_delay"`
 
+	// The minimum 24h quote asset volume traded of the coin.
+	// This is to avoid buying coins with very low trading volume.
+	MinQuoteVolumeTraded float64 `mapstructure:"min_quote_volume_traded"`
+
 	// Configuration for trailing stop loss.
 	TrailingStopOptions TrailingStopOptions `mapstructure:"trailing_stop_options"`
 

--- a/internal/market/binance.go
+++ b/internal/market/binance.go
@@ -42,9 +42,6 @@ func (b *Binance) GetCoins(ctx context.Context) (CoinMap, error) {
 			Price:  priceAsFloat,
 			Time:   now,
 		}
-		if quoteVolume, ok := CoinVolumes[price.Symbol]; ok {
-			coin.QuoteVolumeTraded = quoteVolume
-		}
 		coins[coin.Symbol] = coin
 	}
 

--- a/internal/market/binance.go
+++ b/internal/market/binance.go
@@ -26,13 +26,13 @@ func (b *Binance) Name() string {
 	return "binance"
 }
 
-func (b *Binance) GetCoins(ctx context.Context) (CoinMap, error) {
+func (b *Binance) GetCoins(ctx context.Context) (Coins, error) {
 	prices, err := b.client.NewListPricesService().Do(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	coins := make(CoinMap)
+	coins := make(Coins)
 	now := time.Now()
 
 	for _, price := range prices {

--- a/internal/market/binance.go
+++ b/internal/market/binance.go
@@ -45,9 +45,7 @@ func (b *Binance) GetCoins(ctx context.Context) (CoinMap, error) {
 		if quoteVolume, ok := CoinVolumes[price.Symbol]; ok {
 			coin.QuoteVolumeTraded = quoteVolume
 		}
-		if coin.IsAvailableForTrading(b.config.TradingOptions.AllowList, b.config.TradingOptions.DenyList, b.config.TradingOptions.PairWith, b.config.TradingOptions.MinQuoteVolumeTraded) {
-			coins[coin.Symbol] = coin
-		}
+		coins[coin.Symbol] = coin
 	}
 
 	return coins, nil

--- a/internal/market/binance.go
+++ b/internal/market/binance.go
@@ -48,8 +48,8 @@ func (b *Binance) GetCoins(ctx context.Context) (CoinMap, error) {
 	return coins, nil
 }
 
-func (b *Binance) GetCoinsVolume(ctx context.Context) (CoinVolumeTradedMap, error) {
-	volumeMap := make(CoinVolumeTradedMap)
+func (b *Binance) GetCoinsVolume(ctx context.Context) (TradeVolumes, error) {
+	volumeMap := make(TradeVolumes)
 	if b.config.TradingOptions.MinQuoteVolumeTraded != 0.0 {
 		priceStats24Hours, err := b.client.NewListPriceChangeStatsService().Do(ctx)
 		if err != nil {

--- a/internal/market/coin.go
+++ b/internal/market/coin.go
@@ -34,8 +34,6 @@ type CoinMap map[string]Coin
 
 type CoinVolumeTradedMap map[string]float64
 
-var CoinVolumes CoinVolumeTradedMap
-
 type SymbolInfo struct {
 	// The symbol of the coin.
 	Symbol string

--- a/internal/market/coin.go
+++ b/internal/market/coin.go
@@ -32,7 +32,7 @@ type VolatileCoins map[string]VolatileCoin
 
 type CoinMap map[string]Coin
 
-type CoinVolumeTradedMap map[string]float64
+type TradeVolumes map[string]float64
 
 type SymbolInfo struct {
 	// The symbol of the coin.

--- a/internal/market/coin.go
+++ b/internal/market/coin.go
@@ -30,7 +30,7 @@ type VolatileCoin struct {
 
 type VolatileCoins map[string]VolatileCoin
 
-type CoinMap map[string]Coin
+type Coins map[string]Coin
 
 type TradeVolumes map[string]float64
 

--- a/internal/market/coin.go
+++ b/internal/market/coin.go
@@ -52,7 +52,7 @@ func (c Coin) String() string {
 // IsAvailableForTrading checks if the coin should be picked up by the bot for trading.
 // It checks whether the coin has the desired minimum quote asset trading volume, is in the custom list, and it's not a blacklisted symbol. These options are defined in the given config file.
 func (c Coin) IsAvailableForTrading(allowList, denyList []string, pairWith string, minQuoteVolumeTraded float64) bool {
-	if c.QuoteVolumeTraded < minQuoteVolumeTraded {
+	if minQuoteVolumeTraded != 0.0 && c.QuoteVolumeTraded < minQuoteVolumeTraded {
 		return false
 	}
 	if len(denyList) > 0 {

--- a/internal/market/coin_test.go
+++ b/internal/market/coin_test.go
@@ -10,48 +10,70 @@ func TestCoin_IsAvailableForTrading(t *testing.T) {
 	allowList := []string{"BTC"}
 	denyList := []string{"EURUSDT"}
 	pairWith := "USDT"
+	minQuoteVolumeTraded := 5000.0
 	coin := Coin{
-		Price: 10000,
-		Time:  time.Now(),
+		Price:             10000,
+		QuoteVolumeTraded: 40000,
+		Time:              time.Now(),
 	}
 
 	// test allowlist and denylist
 	coin.Symbol = "BTCUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, denyList, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "ETHUSDT"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "EURUSDT"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "BTCUSDC"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
 
 	// test no allowlist
 	coin.Symbol = "BTCUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "ETHUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "EURUSDT"
-	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "BTCUSDC"
-	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, denyList, pairWith, minQuoteVolumeTraded))
 
 	// test no denylist
 	coin.Symbol = "BTCUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "ETHUSDT"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "EURUSDT"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "BTCUSDC"
-	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, []string{}, pairWith, minQuoteVolumeTraded))
 
 	// test no allowlist and no denylist
 	coin.Symbol = "BTCUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "ETHUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "EURUSDT"
-	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
+	assert.Equal(t, true, coin.IsAvailableForTrading([]string{}, []string{}, pairWith, minQuoteVolumeTraded))
 	coin.Symbol = "BTCUSDC"
-	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, []string{}, pairWith))
+	assert.Equal(t, false, coin.IsAvailableForTrading([]string{}, []string{}, pairWith, minQuoteVolumeTraded))
+
+	// test 24H quote volume threshold
+	coin.Symbol = "BTCUSDT"
+	coin.QuoteVolumeTraded = 4000
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
+	coin.Symbol = "BTCUSDT"
+	coin.QuoteVolumeTraded = 5000
+	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
+	coin.Symbol = "BTCUSDT"
+	coin.QuoteVolumeTraded = 5000
+	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, denyList, pairWith, 5000))
+	coin.Symbol = "BTCUSDT"
+	coin.QuoteVolumeTraded = 6000.0
+	assert.Equal(t, true, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
+	coin.Symbol = "ETHUSDT"
+	coin.QuoteVolumeTraded = 6000
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
+	coin.Symbol = "BTCUSDC"
+	coin.QuoteVolumeTraded = 10000
+	assert.Equal(t, false, coin.IsAvailableForTrading(allowList, denyList, pairWith, minQuoteVolumeTraded))
 }

--- a/internal/market/market.go
+++ b/internal/market/market.go
@@ -15,7 +15,7 @@ type Market interface {
 	GetCoins(ctx context.Context) (CoinMap, error)
 
 	// GetCoinsVolume returns the quote volume traded for all coins on the market.
-	GetCoinsVolume(ctx context.Context) (CoinVolumeTradedMap, error)
+	GetCoinsVolume(ctx context.Context) (TradeVolumes, error)
 
 	// GetSymbolInfo returns the symbol info for the given symbol.
 	GetSymbolInfo(ctx context.Context, symbol string) (SymbolInfo, error)

--- a/internal/market/market.go
+++ b/internal/market/market.go
@@ -12,7 +12,7 @@ type Market interface {
 	Name() string
 
 	// GetCoins returns the current price of all coins on the market.
-	GetCoins(ctx context.Context) (CoinMap, error)
+	GetCoins(ctx context.Context) (Coins, error)
 
 	// GetCoinsVolume returns the quote volume traded for all coins on the market.
 	GetCoinsVolume(ctx context.Context) (TradeVolumes, error)

--- a/internal/market/market.go
+++ b/internal/market/market.go
@@ -14,6 +14,9 @@ type Market interface {
 	// GetCoins returns the current price of all coins on the market.
 	GetCoins(ctx context.Context) (CoinMap, error)
 
+	// GetCoinsVolume returns the quote volume traded for all coins on the market.
+	GetCoinsVolume(ctx context.Context) (CoinVolumeTradedMap, error)
+
 	// GetSymbolInfo returns the symbol info for the given symbol.
 	GetSymbolInfo(ctx context.Context, symbol string) (SymbolInfo, error)
 


### PR DESCRIPTION
This PR adds the ability to filter the asset universe by minimum traded volume amount. This is useful to prevent the bot from generating false signals for coins with very low liquidity. 

Currently implemented for Binance as the total 24-hour quote asset amount traded for the coin, and refreshed every hour to avoid hitting API rate limits.