### PR TITLE
fix: pnl formulas

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -323,6 +323,7 @@ func (b *Bot) sell(ctx context.Context, wg *sync.WaitGroup) {
 					fees = buyFee + sellFee
 					profitLoss := (sellPrice-buyPrice)*order.Volume - fees
 					profitLossPercentage := profitLoss / (buyPrice * order.Volume) * 100
+					order.RealizedProfitLoss = &profitLoss
 					msg = fmt.Sprintf(
 						"Sold %g %s. %s: $%.2f %.2f%%",
 						boughtCoin.Volume,

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -267,8 +267,8 @@ func (b *Bot) sell(ctx context.Context, wg *sync.WaitGroup) {
 
 				// If the price of the coin is below the stop loss or above take profit then sell it.
 				if currentPrice <= stopLoss || currentPrice >= takeProfit {
-					estimatedProfitLoss := (currentPrice - buyPrice) * boughtCoin.Volume * (1 - fees)
-					estimatedProfitLossPercentage := b.config.TradingOptions.Quantity * (priceChangePercentage - fees) / 100
+					estimatedProfitLoss := (currentPrice-buyPrice)*boughtCoin.Volume - fees
+					estimatedProfitLossPercentage := estimatedProfitLoss / (buyPrice * boughtCoin.Volume) * 100
 					msg := fmt.Sprintf(
 						"Selling %g %s. Estimated %s: $%.2f %.2f%%",
 						boughtCoin.Volume,
@@ -321,8 +321,8 @@ func (b *Bot) sell(ctx context.Context, wg *sync.WaitGroup) {
 					sellFee = sellPrice * (b.config.TradingOptions.TradingFeeTaker / 100)
 					priceChangePercentage = (sellPrice - buyPrice) / buyPrice * 100
 					fees = buyFee + sellFee
-					profitLoss := (sellPrice - buyPrice) * order.Volume * (1 - fees)
-					profitLossPercentage := b.config.TradingOptions.Quantity * (priceChangePercentage - fees) / 100
+					profitLoss := (sellPrice-buyPrice)*order.Volume - fees
+					profitLossPercentage := profitLoss / (buyPrice * order.Volume) * 100
 					msg = fmt.Sprintf(
 						"Sold %g %s. %s: $%.2f %.2f%%",
 						boughtCoin.Volume,

--- a/internal/database/models/order.go
+++ b/internal/database/models/order.go
@@ -43,6 +43,10 @@ type Order struct {
 	// This field is only set when the type is a sell order.
 	EstimatedProfitLoss *float64
 
+	// Optional field for the realized profit or loss.
+	// This field is only set when the type is a sell order.
+	RealizedProfitLoss *float64
+
 	// Whether the order is a dummy/fake order, created in test mode.
 	IsTestMode bool
 }


### PR DESCRIPTION
Since `fees` is a dollar amount and not a percentage, the profit and loss formulas needed to be adjusted. 

I've also taken the opportunity to track the realized profit and loss in the database, it might be useful for people who want to find out how much slippage there is when the orders are getting filled.